### PR TITLE
Implement ConnectionFactory Discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,11 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
     </build>
 
     <repositories>

--- a/src/main/java/io/r2dbc/proxy/ProxyConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/proxy/ProxyConnectionFactoryProvider.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.r2dbc.proxy;
+
+import io.r2dbc.proxy.listener.LifeCycleListener;
+import io.r2dbc.proxy.listener.ProxyExecutionListener;
+import io.r2dbc.proxy.util.Assert;
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.ConnectionFactoryProvider;
+import io.r2dbc.spi.Option;
+
+import java.util.Set;
+
+import static java.lang.String.format;
+
+/**
+ * An implementation of {@link ConnectionFactoryProvider} for creating proxy {@link ConnectionFactory}.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class ProxyConnectionFactoryProvider implements ConnectionFactoryProvider {
+
+    /**
+     * Driver option value.
+     */
+    public static final String PROXY_DRIVER = "proxy";
+
+    /**
+     * Fully qualified proxy listener class names.
+     *
+     * Specified class names need to be implementations of ({@link ProxyExecutionListener} or {@link LifeCycleListener}) interfaces.
+     */
+    public static final Option<Set<String>> PROXY_LISTENERS = Option.valueOf("proxyListener");
+
+    private static final String COLON = ":";
+
+    /**
+     * Create a new proxy {@link ConnectionFactory} from given {@link ConnectionFactoryOptions}.
+     *
+     * @param connectionFactoryOptions a collection of {@link ConnectionFactoryOptions}
+     * @return the proxy {@link ConnectionFactory}
+     * @throws IllegalArgumentException if {@code connectionFactoryOptions} is {@code null}
+     * @throws IllegalStateException    if there is no value for {@link ConnectionFactoryOptions#PROTOCOL}
+     * @throws IllegalArgumentException if {@link ConnectionFactoryOptions#PROTOCOL} has invalid format
+     * @throws IllegalArgumentException if specified proxyListener parameter class cannot be found or instantiated
+     * @throws IllegalArgumentException if specified proxyListener parameter value is not a proxy listener class
+     */
+    @Override
+    public ConnectionFactory create(ConnectionFactoryOptions connectionFactoryOptions) {
+        Assert.requireNonNull(connectionFactoryOptions, "connectionFactoryOptions must not be null");
+
+        // To delegate to the next factory provider, inspect the PROTOCOL and convert it to the next DRIVER and PROTOCOL values.
+        //
+        // example:
+        //   | Property | Input        | Output     |
+        //   |----------|--------------|------------|
+        //   | DRIVER   | proxy        | tc         |
+        //   | PROTOCOL | tc:mysql:udp | mysql:udp  |
+        //   |----------|--------------|------------|
+        //   | DRIVER   | proxy        | postgres   |
+        //   | PROTOCOL | postgres     | <empty>    |
+
+        String protocol = connectionFactoryOptions.getRequiredValue(ConnectionFactoryOptions.PROTOCOL);
+        if (protocol.trim().length() == 0) {
+            throw new IllegalArgumentException(format("Protocol %s is not valid.", protocol));
+        }
+        String[] protocols = protocol.split(COLON, 2);
+        String driverDelegate = protocols[0];
+
+        // when protocol does NOT contain COLON, the length becomes 1
+        String protocolDelegate = protocols.length == 2 ? protocols[1] : "";
+
+        ConnectionFactoryOptions newOptions = ConnectionFactoryOptions.builder()
+            .from(connectionFactoryOptions)
+            .option(ConnectionFactoryOptions.DRIVER, driverDelegate)
+            .option(ConnectionFactoryOptions.PROTOCOL, protocolDelegate)
+            .build();
+
+
+        // Run discovery again to find the actual connection factory
+        ConnectionFactory connectionFactory = ConnectionFactories.find(newOptions);
+        if (connectionFactory == null) {
+            return null;
+        }
+
+        ProxyConnectionFactory.Builder builder = ProxyConnectionFactory.builder(connectionFactory);
+
+        // add proxy listeners if specified
+        if (connectionFactoryOptions.hasOption(PROXY_LISTENERS)) {
+            connectionFactoryOptions.getValue(PROXY_LISTENERS).forEach(proxyListener -> {
+
+                Object listener;
+                try {
+                    Class<?> proxyListenerClass = Class.forName(proxyListener);
+                    listener = proxyListenerClass.newInstance();
+                } catch (Exception e) {
+                    String message = proxyListener + " is not a valid proxy listener class";
+                    throw new IllegalArgumentException(message, e);
+                }
+
+                // currently two types of listeners exist
+                if (listener instanceof ProxyExecutionListener) {
+                    builder.listener((ProxyExecutionListener) listener);
+                } else if (listener instanceof LifeCycleListener) {
+                    builder.listener((LifeCycleListener) listener);
+                } else {
+                    throw new IllegalArgumentException(proxyListener + " is not a proxy listener class");
+                }
+
+            });
+        }
+
+        return builder.create();
+    }
+
+    @Override
+    public boolean supports(ConnectionFactoryOptions connectionFactoryOptions) {
+        Assert.requireNonNull(connectionFactoryOptions, "connectionFactoryOptions must not be null");
+
+        String driver = connectionFactoryOptions.getValue(ConnectionFactoryOptions.DRIVER);
+        return PROXY_DRIVER.equals(driver);
+    }
+
+}

--- a/src/main/resources/META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider
+++ b/src/main/resources/META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider
@@ -1,0 +1,1 @@
+io.r2dbc.proxy.ProxyConnectionFactoryProvider

--- a/src/test/java/io/r2dbc/proxy/MockConnectionFactoryProvider.java
+++ b/src/test/java/io/r2dbc/proxy/MockConnectionFactoryProvider.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.r2dbc.proxy;
+
+import io.r2dbc.proxy.util.Assert;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.ConnectionFactoryProvider;
+
+import java.util.ServiceLoader;
+import java.util.function.Function;
+
+/**
+ * Mock implementation of {@link ConnectionFactoryProvider} for testing.
+ *
+ * <p>This class provides static access to the callbacks for implemented {@link ConnectionFactory} methods.
+ * When this class is registered to {@link ServiceLoader} discovery mechanism, those static methods can set
+ * behavior for the callbacks and have access to the invoked parameters.
+ *
+ * @author Tadaya Tsuyukubo
+ * @see ServiceLoader
+ */
+public class MockConnectionFactoryProvider implements ConnectionFactoryProvider {
+
+    private static Function<ConnectionFactoryOptions, ConnectionFactory> DEFAULT_CREATE_CALLBACK = connectionFactoryOptions -> null;
+
+    private static Function<ConnectionFactoryOptions, Boolean> DEFAULT_SUPPORTS_CALLBACK = connectionFactoryOptions -> false;
+
+    private static Function<ConnectionFactoryOptions, ConnectionFactory> createCallback = DEFAULT_CREATE_CALLBACK;
+
+    private static Function<ConnectionFactoryOptions, Boolean> supportsCallback = DEFAULT_SUPPORTS_CALLBACK;
+
+    /**
+     * Reset the registered callbacks to the default.
+     */
+    public static void reset() {
+        createCallback = DEFAULT_CREATE_CALLBACK;
+        supportsCallback = DEFAULT_SUPPORTS_CALLBACK;
+    }
+
+    /**
+     * Make {@link #supports(ConnectionFactoryOptions)} always return {@code true}.
+     */
+    public static void setSupportsAlways() {
+        supportsCallback = connectionFactoryOptions -> true;
+    }
+
+    /**
+     * Make {@link #create(ConnectionFactoryOptions)} to return the given {@link ConnectionFactory} instance.
+     *
+     * @param connectionFactory connectionFactory to return
+     * @throws IllegalArgumentException if {@code connectionFactory} is {@code null}
+     */
+    public static void setCreateCallbackReturn(ConnectionFactory connectionFactory) {
+        Assert.requireNonNull(connectionFactory, "connectionFactory must not be null");
+        createCallback = connectionFactoryOptions -> connectionFactory;
+    }
+
+    /**
+     * Set the callback which is invoked when {@link #supports(ConnectionFactoryOptions)} is called.
+     *
+     * @param callback a callback for {@link #supports(ConnectionFactoryOptions)}
+     * @throws IllegalArgumentException if {@code callback} is {@code null}
+     */
+    public static void setSupportsCallback(Function<ConnectionFactoryOptions, Boolean> callback) {
+        supportsCallback = Assert.requireNonNull(callback, "callback must not be null");
+    }
+
+    /**
+     * Set the callback which is invoked when {@link #create(ConnectionFactoryOptions)} is called.
+     *
+     * @param callback a callback for {@link #create(ConnectionFactoryOptions)}
+     * @throws IllegalArgumentException if {@code callback} is {@code null}
+     */
+    public static void setCreateCallback(Function<ConnectionFactoryOptions, ConnectionFactory> callback) {
+        createCallback = Assert.requireNonNull(callback, "callback must not be null");
+    }
+
+    @Override
+    public ConnectionFactory create(ConnectionFactoryOptions connectionFactoryOptions) {
+        return createCallback.apply(connectionFactoryOptions);
+    }
+
+    @Override
+    public boolean supports(ConnectionFactoryOptions connectionFactoryOptions) {
+        return supportsCallback.apply(connectionFactoryOptions);
+    }
+
+}

--- a/src/test/java/io/r2dbc/proxy/ProxyConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/proxy/ProxyConnectionFactoryProviderTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.r2dbc.proxy;
+
+import io.r2dbc.proxy.listener.ProxyExecutionListener;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Wrapped;
+import io.r2dbc.spi.test.MockConnectionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.r2dbc.proxy.ProxyConnectionFactoryProvider.PROXY_LISTENERS;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test for {@link ProxyConnectionFactoryProvider}
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class ProxyConnectionFactoryProviderTest {
+
+    private ProxyConnectionFactoryProvider provider = new ProxyConnectionFactoryProvider();
+
+    @BeforeEach
+    void setUp() {
+        MockConnectionFactoryProvider.reset();
+        TestProxyExecutionListener.reset();
+    }
+
+    @Test
+    void doesNotSupportWithWrongDriver() {
+        assertThat(this.provider.supports(ConnectionFactoryOptions.builder()
+            .option(DRIVER, "non-proxy")
+            .build())).isFalse();
+    }
+
+    @Test
+    void doesNotSupportWithoutDriver() {
+        assertThat(this.provider.supports(ConnectionFactoryOptions.builder()
+            .build())).isFalse();
+    }
+
+    @Test
+    void supports() {
+        assertThat(this.provider.supports(ConnectionFactoryOptions.builder()
+            .option(DRIVER, "proxy")
+            .build())).isTrue();
+
+        assertThat(this.provider.supports(ConnectionFactoryOptions.builder()
+            .option(DRIVER, "proxy")
+            .option(HOST, "my-host")
+            .build())).isTrue();
+    }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void create() {
+        AtomicReference<ConnectionFactoryOptions> receivedOptionsHolder = new AtomicReference<>();
+
+        MockConnectionFactory connectionFactory = MockConnectionFactory.empty();
+        MockConnectionFactoryProvider.setSupportsAlways();
+        MockConnectionFactoryProvider.setCreateCallback(connectionFactoryOptions -> {
+            receivedOptionsHolder.set(connectionFactoryOptions);
+            return connectionFactory;
+        });
+
+        ConnectionFactory factory = this.provider.create(ConnectionFactoryOptions.builder()
+            .option(DRIVER, "proxy")
+            .option(PROTOCOL, "foo")
+            .build());
+
+        assertThat(factory).isInstanceOf(Wrapped.class);
+        ConnectionFactory unwrapped = ((Wrapped<ConnectionFactory>) factory).unwrap();
+        assertThat(unwrapped).isSameAs(connectionFactory);
+
+        ConnectionFactoryOptions receivedOptions = receivedOptionsHolder.get();
+        String receivedDriver = receivedOptions.getValue(DRIVER);
+        String receivedProtocol = receivedOptions.getValue(PROTOCOL);
+
+        assertThat(receivedDriver).isEqualTo("foo");
+        assertThat(receivedProtocol).isEmpty();
+    }
+
+    @Test
+    void createWithNestedProtocol() {
+        AtomicReference<ConnectionFactoryOptions> receivedOptionsHolder = new AtomicReference<>();
+
+        MockConnectionFactoryProvider.setSupportsAlways();
+        MockConnectionFactoryProvider.setCreateCallback(connectionFactoryOptions -> {
+            receivedOptionsHolder.set(connectionFactoryOptions);
+            return MockConnectionFactory.empty();
+        });
+
+        this.provider.create(ConnectionFactoryOptions.builder()
+            .option(DRIVER, "proxy")
+            .option(PROTOCOL, "foo:bar:baz")
+            .build());
+
+        ConnectionFactoryOptions receivedOptions = receivedOptionsHolder.get();
+        String receivedDriver = receivedOptions.getValue(DRIVER);
+        String receivedProtocol = receivedOptions.getValue(PROTOCOL);
+
+        assertThat(receivedDriver).isEqualTo("foo");
+        assertThat(receivedProtocol).isEqualTo("bar:baz");
+    }
+
+    @Test
+    void createWithValidListener() {
+        MockConnectionFactory connectionFactory = MockConnectionFactory.empty();
+        MockConnectionFactoryProvider.setSupportsAlways();
+        MockConnectionFactoryProvider.setCreateCallbackReturn(connectionFactory);
+
+        Set<String> listenerClasses = Collections.singleton(TestProxyExecutionListener.class.getName());
+        this.provider.create(ConnectionFactoryOptions.builder()
+            .option(DRIVER, "proxy")
+            .option(PROTOCOL, "foo")
+            .option(PROXY_LISTENERS, listenerClasses)
+            .build());
+
+        assertThat(TestProxyExecutionListener.isInstantiated())
+            .as("Listener should be instantiated")
+            .isTrue();
+    }
+
+    @Test
+    void invalidProtocol() {
+
+        ConnectionFactoryOptions emptyProtocolOptions = ConnectionFactoryOptions.builder()
+            .option(DRIVER, "proxy")
+            .option(PROTOCOL, "")  // empty name
+            .build();
+
+        assertThatThrownBy(() -> this.provider.create(emptyProtocolOptions))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Protocol  is not valid.");
+
+        ConnectionFactoryOptions whiteSpaceProtocolOptions = ConnectionFactoryOptions.builder()
+            .option(DRIVER, "proxy")
+            .option(PROTOCOL, "  ")  // name with spaces
+            .build();
+
+        assertThatThrownBy(() -> this.provider.create(whiteSpaceProtocolOptions))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Protocol    is not valid.");
+
+        ConnectionFactoryOptions noProtocolOptions = ConnectionFactoryOptions.builder()
+            .option(DRIVER, "proxy")
+            .build();
+
+        assertThatThrownBy(() -> this.provider.create(noProtocolOptions))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("No value found for protocol");
+
+    }
+
+    @Test
+    void invalidListenerClassName() {
+
+        MockConnectionFactoryProvider.setSupportsAlways();
+        MockConnectionFactoryProvider.setCreateCallbackReturn(MockConnectionFactory.empty());
+
+        ConnectionFactoryOptions invalidListenerClassNameOptions = ConnectionFactoryOptions.builder()
+            .option(DRIVER, "proxy")
+            .option(PROTOCOL, "foo")
+            .option(PROXY_LISTENERS, Collections.singleton("invalid.class"))
+            .build();
+
+        assertThatThrownBy(() -> this.provider.create(invalidListenerClassNameOptions))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("invalid.class is not a valid proxy listener class");
+
+    }
+
+    @Test
+    void invalidListenerClass() {
+
+        MockConnectionFactoryProvider.setSupportsAlways();
+        MockConnectionFactoryProvider.setCreateCallbackReturn(MockConnectionFactory.empty());
+
+        String invalidListenerClassName = InvalidTestProxyExecutionListener.class.getName();
+        ConnectionFactoryOptions invalidListenerClassNameOptions = ConnectionFactoryOptions.builder()
+            .option(DRIVER, "proxy")
+            .option(PROTOCOL, "foo")
+            .option(PROXY_LISTENERS, Collections.singleton(invalidListenerClassName))
+            .build();
+
+        assertThatThrownBy(() -> this.provider.create(invalidListenerClassNameOptions))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(invalidListenerClassName + " is not a proxy listener class");
+
+    }
+
+    static class TestProxyExecutionListener implements ProxyExecutionListener {
+
+        static boolean instantiated = false;
+
+        public TestProxyExecutionListener() {
+            instantiated = true;
+        }
+
+        static boolean isInstantiated() {
+            return instantiated;
+        }
+
+        static void reset() {
+            instantiated = false;
+        }
+
+    }
+
+    /**
+     * Does NOT implement {@link ProxyExecutionListener}.
+     */
+    static class InvalidTestProxyExecutionListener {
+
+    }
+
+}

--- a/src/test/resources/META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider
+++ b/src/test/resources/META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider
@@ -1,0 +1,1 @@
+io.r2dbc.proxy.MockConnectionFactoryProvider


### PR DESCRIPTION
ConnectionFactoryProvider implementation for proxy.

For delegation logic (`DRIVER` and `PROTOCOL` option handling), implemented as discussed in 
https://github.com/r2dbc/r2dbc-spi/issues/37#issuecomment-455505963
