### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ is to create a watcher that checks running queries and notify ones exceeded the 
 In [datasource-proxy](datasource-proxy), [`SlowQueryListener` is implemented in this way][slow-query-doc].
 
 [datasource-proxy]: https://github.com/ttddyy/datasource-proxy
-[slow-query-doc]: http://ttddyy.github.io/datasource-proxy/docs/current/user-guide/#_slow_query_logging_listener
+[slow-query-doc]: https://ttddyy.github.io/datasource-proxy/docs/current/user-guide/#_slow_query_logging_listener
 
 
 ### Distributed Tracing


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://ttddyy.github.io/datasource-proxy/docs/current/user-guide/ with 1 occurrences migrated to:  
  https://ttddyy.github.io/datasource-proxy/docs/current/user-guide/ ([https](https://ttddyy.github.io/datasource-proxy/docs/current/user-guide/) result 200).