### PR TITLE
Restrict CI and release task to r2dbc/r2dbc-proxy repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'r2dbc/r2dbc-proxy'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'r2dbc/r2dbc-proxy'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Similar to r2dbc/r2dbc-mssql#179, this change will restrict GitHub Actions that rely on secrets to only run on the main repository (r2dbc/r2dbc-proxy). This prevents actions on forks from running and then failing due to absent secrets.