### PR TITLE
feat: call afterQuery only when query is fully executed 

### DIFF
--- a/src/main/java/io/r2dbc/proxy/callback/CallbackHandlerSupport.java
+++ b/src/main/java/io/r2dbc/proxy/callback/CallbackHandlerSupport.java
@@ -213,15 +213,16 @@ abstract class CallbackHandlerSupport implements CallbackHandler {
         Assert.requireNonNull(publisher, "flux must not be null");
         Assert.requireNonNull(executionInfo, "executionInfo must not be null");
 
+        QueriesExecutionCounter queriesExecutionCounter = new QueriesExecutionCounter(new StopWatch(this.proxyConfig.getClock()));
         ProxyFactory proxyFactory = this.proxyConfig.getProxyFactory();
         Function<? super Publisher<Result>, ? extends Publisher<Result>> transformer =
             Operators.liftPublisher((pub, subscriber) ->
-                new QueryInvocationSubscriber(subscriber, executionInfo, proxyConfig));
+                new QueryInvocationSubscriber(subscriber, executionInfo, proxyConfig, queriesExecutionCounter));
 
         return Flux.from(publisher)
             .cast(Result.class)
             .transform(transformer)
-            .map(queryResult -> proxyFactory.wrapResult(queryResult, executionInfo));
+            .map(queryResult -> proxyFactory.wrapResult(queryResult, executionInfo, queriesExecutionCounter));
     }
 
     /**

--- a/src/main/java/io/r2dbc/proxy/callback/JdkProxyFactory.java
+++ b/src/main/java/io/r2dbc/proxy/callback/JdkProxyFactory.java
@@ -94,11 +94,11 @@ final class JdkProxyFactory implements ProxyFactory {
     }
 
     @Override
-    public Result wrapResult(Result result, QueryExecutionInfo queryExecutionInfo) {
+    public Result wrapResult(Result result, QueryExecutionInfo queryExecutionInfo, QueriesExecutionCounter queriesExecutionCounter) {
         Assert.requireNonNull(result, "result must not be null");
         Assert.requireNonNull(queryExecutionInfo, "queryExecutionInfo must not be null");
 
-        CallbackHandler logic = new ResultCallbackHandler(result, queryExecutionInfo, this.proxyConfig);
+        CallbackHandler logic = new ResultCallbackHandler(result, queryExecutionInfo, this.proxyConfig, queriesExecutionCounter);
         CallbackInvocationHandler invocationHandler = new CallbackInvocationHandler(logic);
         return createProxy(invocationHandler, Result.class, Wrapped.class, ConnectionHolder.class, ProxyConfigHolder.class);
     }

--- a/src/main/java/io/r2dbc/proxy/callback/MutableQueryExecutionInfo.java
+++ b/src/main/java/io/r2dbc/proxy/callback/MutableQueryExecutionInfo.java
@@ -23,6 +23,7 @@ import io.r2dbc.proxy.core.ProxyEventType;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.proxy.core.ValueStore;
+import io.r2dbc.spi.Result;
 import reactor.util.annotation.Nullable;
 
 import java.lang.reflect.Method;
@@ -209,5 +210,4 @@ final class MutableQueryExecutionInfo implements QueryExecutionInfo {
     public Object getCurrentMappedResult() {
         return currentMappedResult;
     }
-
 }

--- a/src/main/java/io/r2dbc/proxy/callback/ProxyFactory.java
+++ b/src/main/java/io/r2dbc/proxy/callback/ProxyFactory.java
@@ -86,6 +86,6 @@ public interface ProxyFactory {
      * @throws IllegalArgumentException if {@code result} is {@code null}
      * @throws IllegalArgumentException if {@code executionInfo} is {@code null}
      */
-    Result wrapResult(Result result, QueryExecutionInfo executionInfo);
+    Result wrapResult(Result result, QueryExecutionInfo executionInfo, QueriesExecutionCounter queriesExecutionCounter);
 
 }

--- a/src/main/java/io/r2dbc/proxy/callback/QueriesExecutionCounter.java
+++ b/src/main/java/io/r2dbc/proxy/callback/QueriesExecutionCounter.java
@@ -1,0 +1,54 @@
+package io.r2dbc.proxy.callback;
+
+import java.time.Duration;
+
+/**
+ * Utility class to know how many result are processing and if all result has been processed.
+ *
+ * @author Thomas Deblock
+ */
+public class QueriesExecutionCounter {
+    private int numberOfGeneratedResult;
+    private int numberOfProcessedResult;
+    private boolean allResultHasBeenGenerated;
+    private final StopWatch stopWatch;
+
+    public QueriesExecutionCounter(StopWatch stopWatch) {
+        this.numberOfGeneratedResult = 0;
+        this.numberOfProcessedResult = 0;
+        this.allResultHasBeenGenerated = false;
+        this.stopWatch = stopWatch;
+    }
+
+    public void addGeneratedResult() {
+        this.numberOfGeneratedResult++;
+    }
+
+    public Duration getElapsedDuration() {
+        return this.stopWatch.getElapsedDuration();
+    }
+
+    public void queryStarted() {
+        this.stopWatch.start();
+    }
+
+    public void resultProcessed() {
+        this.numberOfProcessedResult++;
+    }
+
+    public boolean isQueryEnded() {
+        return this.areAllResultProcessed() && this.areAllResultGenerated();
+    }
+
+    public boolean areAllResultProcessed() {
+        return this.numberOfProcessedResult >= this.numberOfGeneratedResult;
+    }
+
+    public boolean areAllResultGenerated() {
+        return this.allResultHasBeenGenerated;
+    }
+
+    public void allResultHasBeenGenerated() {
+        this.allResultHasBeenGenerated = true;
+    }
+}

--- a/src/test/java/io/r2dbc/proxy/callback/JdkProxyFactoryTest.java
+++ b/src/test/java/io/r2dbc/proxy/callback/JdkProxyFactoryTest.java
@@ -76,7 +76,7 @@ public class JdkProxyFactoryTest {
         ConnectionInfo connectionInfo = MockConnectionInfo.empty();
         StatementInfo statementInfo = MockStatementInfo.empty();
         QueryExecutionInfo queryExecutionInfo = new MutableQueryExecutionInfo();  // need to be mutable
-
+        QueriesExecutionCounter queriesExecutionCounter = mock(QueriesExecutionCounter.class);
         Object wrapped;
 
         wrapped = this.proxyFactory.wrapConnectionFactory(connectionFactory);
@@ -103,7 +103,7 @@ public class JdkProxyFactoryTest {
         assertThat(wrapped).isInstanceOf(ConnectionHolder.class);
         assertThat(wrapped).isInstanceOf(ProxyConfigHolder.class);
 
-        wrapped = this.proxyFactory.wrapResult(result, queryExecutionInfo);
+        wrapped = this.proxyFactory.wrapResult(result, queryExecutionInfo, queriesExecutionCounter);
         assertThat(Proxy.isProxyClass(wrapped.getClass())).isTrue();
         assertThat(wrapped).isInstanceOf(Wrapped.class);
         assertThat(wrapped).isInstanceOf(ConnectionHolder.class);

--- a/src/test/java/io/r2dbc/proxy/callback/ProxyUtilsTest.java
+++ b/src/test/java/io/r2dbc/proxy/callback/ProxyUtilsTest.java
@@ -56,10 +56,11 @@ public class ProxyUtilsTest {
 
         MutableQueryExecutionInfo queryExecutionInfo = new MutableQueryExecutionInfo();
         queryExecutionInfo.setConnectionInfo(connectionInfo);
+        QueriesExecutionCounter queriesExecutionCounter = new QueriesExecutionCounter(new StopWatch(proxyConfig.getClock()));
 
         Batch proxyBatch = proxyConfig.getProxyFactory().wrapBatch(originalBatch, connectionInfo);
         Statement proxyStatement = proxyConfig.getProxyFactory().wrapStatement(originalStatement, statementInfo, connectionInfo);
-        Result proxyResult = proxyConfig.getProxyFactory().wrapResult(originalResult, queryExecutionInfo);
+        Result proxyResult = proxyConfig.getProxyFactory().wrapResult(originalResult, queryExecutionInfo, queriesExecutionCounter);
 
         Optional<Connection> result;
 

--- a/src/test/java/io/r2dbc/proxy/callback/ResultCallbackHandlerTest.java
+++ b/src/test/java/io/r2dbc/proxy/callback/ResultCallbackHandlerTest.java
@@ -56,7 +56,7 @@ public class ResultCallbackHandlerTest {
 
 
     @Test
-    void map() throws Throwable {
+    void mapWhenAllResultAreNotAlreadyGenerated() throws Throwable {
         LastExecutionAwareListener listener = new LastExecutionAwareListener();
 
         MutableQueryExecutionInfo queryExecutionInfo = new MutableQueryExecutionInfo();
@@ -66,8 +66,10 @@ public class ResultCallbackHandlerTest {
         Row row2 = MockRow.builder().identified(0, String.class, "bar").build();
         Row row3 = MockRow.builder().identified(0, String.class, "baz").build();
         Result mockResult = MockResult.builder().row(row1, row2, row3).rowMetadata(MockRowMetadata.empty()).build();
+        QueriesExecutionCounter queriesExecutionCounter = new QueriesExecutionCounter(mock(StopWatch.class));
+        queriesExecutionCounter.addGeneratedResult();
 
-        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig);
+        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig, queriesExecutionCounter);
 
         // map function to return the String value
         BiFunction<Row, RowMetadata, String> mapBiFunction = (row, rowMetadata) -> row.get(0, String.class);
@@ -94,6 +96,7 @@ public class ResultCallbackHandlerTest {
                 assertThat(queryExecutionInfo.getThreadId()).isEqualTo(threadId);
                 assertThat(queryExecutionInfo.getThreadName()).isEqualTo(threadName);
                 assertThat(queryExecutionInfo.getThrowable()).isNull();
+                assertThat(queriesExecutionCounter.areAllResultProcessed()).isFalse();
             })
             .assertNext(obj -> {  // second
                 assertThat(obj).isEqualTo("bar");
@@ -106,6 +109,7 @@ public class ResultCallbackHandlerTest {
                 assertThat(queryExecutionInfo.getThreadId()).isEqualTo(threadId);
                 assertThat(queryExecutionInfo.getThreadName()).isEqualTo(threadName);
                 assertThat(queryExecutionInfo.getThrowable()).isNull();
+                assertThat(queriesExecutionCounter.areAllResultProcessed()).isFalse();
             })
             .assertNext(obj -> {  // third
                 assertThat(obj).isEqualTo("baz");
@@ -118,13 +122,16 @@ public class ResultCallbackHandlerTest {
                 assertThat(queryExecutionInfo.getThreadId()).isEqualTo(threadId);
                 assertThat(queryExecutionInfo.getThreadName()).isEqualTo(threadName);
                 assertThat(queryExecutionInfo.getThrowable()).isNull();
+                assertThat(queriesExecutionCounter.areAllResultProcessed()).isFalse();
             })
             .verifyComplete();
 
+        assertThat(queriesExecutionCounter.areAllResultProcessed()).isTrue();
+        assertThat(queryExecutionInfo.getProxyEventType()).isEqualTo(ProxyEventType.EACH_QUERY_RESULT).as("alert query has not be called");
     }
 
     @Test
-    void mapWithPublisherException() throws Throwable {
+    void mapWithPublisherExceptionWhenAllResultAreNotAlreadyGenerated() throws Throwable {
         LastExecutionAwareListener listener = new LastExecutionAwareListener();
 
         MutableQueryExecutionInfo queryExecutionInfo = new MutableQueryExecutionInfo();
@@ -138,7 +145,9 @@ public class ResultCallbackHandlerTest {
         Result mockResult = mock(Result.class);
         when(mockResult.map(any())).thenReturn(publisher);
 
-        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig);
+        QueriesExecutionCounter queriesExecutionCounter = new QueriesExecutionCounter(mock(StopWatch.class));
+
+        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig, queriesExecutionCounter);
 
         // since "mockResult.map()" is mocked, args can be anything as long as num of args matches to signature.
         Object[] args = new Object[]{null};
@@ -150,6 +159,7 @@ public class ResultCallbackHandlerTest {
         long threadId = Thread.currentThread().getId();
         String threadName = Thread.currentThread().getName();
 
+        queriesExecutionCounter.addGeneratedResult();
         StepVerifier.create((Publisher<?>) result)
             .expectSubscription()
             .consumeErrorWith(thrown -> {
@@ -159,7 +169,6 @@ public class ResultCallbackHandlerTest {
 
         assertThat(listener.getEachQueryResultExecutionInfo()).isSameAs(queryExecutionInfo);
 
-        // verify EACH_QUERY_RESULT
         assertThat(queryExecutionInfo.getProxyEventType()).isEqualTo(ProxyEventType.EACH_QUERY_RESULT);
         assertThat(queryExecutionInfo.getCurrentResultCount()).isEqualTo(1);
         assertThat(queryExecutionInfo.getCurrentMappedResult()).isNull();
@@ -168,7 +177,7 @@ public class ResultCallbackHandlerTest {
     }
 
     @Test
-    void mapWithEmptyPublisher() throws Throwable {
+    void mapWithEmptyPublisherWhenAllResultAreNotAlreadyGenerated() throws Throwable {
         LastExecutionAwareListener listener = new LastExecutionAwareListener();
 
         MutableQueryExecutionInfo queryExecutionInfo = new MutableQueryExecutionInfo();
@@ -183,8 +192,9 @@ public class ResultCallbackHandlerTest {
             return null;
         };
 
+        QueriesExecutionCounter queriesExecutionCounter = new QueriesExecutionCounter(mock(StopWatch.class));
 
-        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig);
+        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig, queriesExecutionCounter);
 
         // since "mockResult.map()" is mocked, args can be anything as long as num of args matches to signature.
         Object[] args = new Object[]{mapBiFunction};
@@ -202,8 +212,177 @@ public class ResultCallbackHandlerTest {
     }
 
     @Test
+    void mapWhenAllResultHasBeenGenerated() throws Throwable {
+        LastExecutionAwareListener listener = new LastExecutionAwareListener();
+
+        MutableQueryExecutionInfo queryExecutionInfo = new MutableQueryExecutionInfo();
+        ProxyConfig proxyConfig = ProxyConfig.builder().listener(listener).build();
+
+        Row row1 = MockRow.builder().identified(0, String.class, "foo").build();
+        Row row2 = MockRow.builder().identified(0, String.class, "bar").build();
+        Row row3 = MockRow.builder().identified(0, String.class, "baz").build();
+        Result mockResult = MockResult.builder().row(row1, row2, row3).rowMetadata(MockRowMetadata.empty()).build();
+
+        QueriesExecutionCounter queriesExecutionCounter = new QueriesExecutionCounter(mock(StopWatch.class));
+        queriesExecutionCounter.addGeneratedResult();
+        queriesExecutionCounter.allResultHasBeenGenerated();
+
+        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig, queriesExecutionCounter);
+
+        // map function to return the String value
+        BiFunction<Row, RowMetadata, String> mapBiFunction = (row, rowMetadata) -> row.get(0, String.class);
+
+        Object[] args = new Object[]{mapBiFunction};
+        Object result = callback.invoke(mockResult, MAP_METHOD, args);
+
+        assertThat(result)
+            .isInstanceOf(Publisher.class);
+
+        long threadId = Thread.currentThread().getId();
+        String threadName = Thread.currentThread().getName();
+
+        StepVerifier.create((Publisher<?>) result)
+            .expectSubscription()
+            .assertNext(obj -> {  // first
+                assertThat(obj).isEqualTo("foo");
+                assertThat(listener.getEachQueryResultExecutionInfo()).isSameAs(queryExecutionInfo);
+
+                // verify EACH_QUERY_RESULT
+                assertThat(queryExecutionInfo.getProxyEventType()).isEqualTo(ProxyEventType.EACH_QUERY_RESULT);
+                assertThat(queryExecutionInfo.getCurrentResultCount()).isEqualTo(1);
+                assertThat(queryExecutionInfo.getCurrentMappedResult()).isEqualTo("foo");
+                assertThat(queryExecutionInfo.getThreadId()).isEqualTo(threadId);
+                assertThat(queryExecutionInfo.getThreadName()).isEqualTo(threadName);
+                assertThat(queryExecutionInfo.getThrowable()).isNull();
+                assertThat(queriesExecutionCounter.areAllResultProcessed()).isFalse();
+            })
+            .assertNext(obj -> {  // second
+                assertThat(obj).isEqualTo("bar");
+                assertThat(listener.getEachQueryResultExecutionInfo()).isSameAs(queryExecutionInfo);
+
+                // verify EACH_QUERY_RESULT
+                assertThat(queryExecutionInfo.getProxyEventType()).isEqualTo(ProxyEventType.EACH_QUERY_RESULT);
+                assertThat(queryExecutionInfo.getCurrentResultCount()).isEqualTo(2);
+                assertThat(queryExecutionInfo.getCurrentMappedResult()).isEqualTo("bar");
+                assertThat(queryExecutionInfo.getThreadId()).isEqualTo(threadId);
+                assertThat(queryExecutionInfo.getThreadName()).isEqualTo(threadName);
+                assertThat(queryExecutionInfo.getThrowable()).isNull();
+                assertThat(queriesExecutionCounter.areAllResultProcessed()).isFalse();
+            })
+            .assertNext(obj -> {  // third
+                assertThat(obj).isEqualTo("baz");
+                assertThat(listener.getEachQueryResultExecutionInfo()).isSameAs(queryExecutionInfo);
+
+                // verify EACH_QUERY_RESULT
+                assertThat(queryExecutionInfo.getProxyEventType()).isEqualTo(ProxyEventType.EACH_QUERY_RESULT);
+                assertThat(queryExecutionInfo.getCurrentResultCount()).isEqualTo(3);
+                assertThat(queryExecutionInfo.getCurrentMappedResult()).isEqualTo("baz");
+                assertThat(queryExecutionInfo.getThreadId()).isEqualTo(threadId);
+                assertThat(queryExecutionInfo.getThreadName()).isEqualTo(threadName);
+                assertThat(queryExecutionInfo.getThrowable()).isNull();
+                assertThat(queriesExecutionCounter.areAllResultProcessed()).isFalse();
+            })
+            .verifyComplete();
+
+        assertThat(queriesExecutionCounter.areAllResultProcessed()).isTrue();
+        assertThat(queryExecutionInfo.getProxyEventType()).isEqualTo(ProxyEventType.AFTER_QUERY);
+        assertThat(queryExecutionInfo.getCurrentMappedResult()).isEqualTo(null);
+        assertThat(queryExecutionInfo.getCurrentMappedResult()).isEqualTo(null);
+        assertThat(queryExecutionInfo.getThreadId()).isEqualTo(threadId);
+        assertThat(queryExecutionInfo.getThreadName()).isEqualTo(threadName);
+        assertThat(queryExecutionInfo.getThrowable()).isNull();
+    }
+
+    @Test
+    void mapWithPublisherExceptionWhenAllHasBeenGenerated() throws Throwable {
+        LastExecutionAwareListener listener = new LastExecutionAwareListener();
+
+        MutableQueryExecutionInfo queryExecutionInfo = new MutableQueryExecutionInfo();
+        ProxyConfig proxyConfig = ProxyConfig.builder().listener(listener).build();
+
+
+        // return a publisher that throws exception at execution
+        Exception exception = new RuntimeException("map exception");
+        TestPublisher<Object> publisher = TestPublisher.create().error(exception);
+
+        Result mockResult = mock(Result.class);
+        when(mockResult.map(any())).thenReturn(publisher);
+
+        QueriesExecutionCounter queriesExecutionCounter = new QueriesExecutionCounter(mock(StopWatch.class));
+
+        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig, queriesExecutionCounter);
+
+        // since "mockResult.map()" is mocked, args can be anything as long as num of args matches to signature.
+        Object[] args = new Object[]{null};
+        Object result = callback.invoke(mockResult, MAP_METHOD, args);
+
+        assertThat(result).isInstanceOf(Publisher.class);
+        assertThat(result).isNotSameAs(publisher);
+
+        long threadId = Thread.currentThread().getId();
+        String threadName = Thread.currentThread().getName();
+
+        queriesExecutionCounter.addGeneratedResult();
+        queriesExecutionCounter.allResultHasBeenGenerated();
+
+        StepVerifier.create((Publisher<?>) result)
+            .expectSubscription()
+            .consumeErrorWith(thrown -> {
+                assertThat(thrown).isSameAs(exception);
+            })
+            .verify();
+
+        assertThat(listener.getEachQueryResultExecutionInfo()).isSameAs(queryExecutionInfo);
+
+        assertThat(queryExecutionInfo.getProxyEventType()).isEqualTo(ProxyEventType.AFTER_QUERY);
+        assertThat(queryExecutionInfo.getCurrentMappedResult()).isEqualTo(null);
+        assertThat(queryExecutionInfo.getCurrentMappedResult()).isNull();
+        assertThat(queryExecutionInfo.getThreadId()).isEqualTo(threadId);
+        assertThat(queryExecutionInfo.getThreadName()).isEqualTo(threadName);
+    }
+
+    @Test
+    void mapWithEmptyPublisherWhenAllResultHasBeenGenerated() throws Throwable {
+        LastExecutionAwareListener listener = new LastExecutionAwareListener();
+
+        MutableQueryExecutionInfo queryExecutionInfo = new MutableQueryExecutionInfo();
+        ProxyConfig proxyConfig = ProxyConfig.builder().listener(listener).build();
+
+        // return empty result
+        Result mockResult = MockResult.builder().build();
+
+        QueriesExecutionCounter queriesExecutionCounter = new QueriesExecutionCounter(mock(StopWatch.class));
+        queriesExecutionCounter.addGeneratedResult();
+        queriesExecutionCounter.allResultHasBeenGenerated();
+
+        AtomicBoolean isCalled = new AtomicBoolean();
+        BiFunction<Row, RowMetadata, String> mapBiFunction = (row, rowMetadata) -> {
+            isCalled.set(true);
+            return null;
+        };
+
+        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig, queriesExecutionCounter);
+
+        // since "mockResult.map()" is mocked, args can be anything as long as num of args matches to signature.
+        Object[] args = new Object[]{mapBiFunction};
+        Object result = callback.invoke(mockResult, MAP_METHOD, args);
+
+        assertThat(result).isInstanceOf(Publisher.class);
+        assertThat(isCalled).as("map function should not be called").isFalse();
+
+        StepVerifier.create((Publisher<?>) result)
+            .expectSubscription()
+            .verifyComplete();
+
+        assertThat(listener.getAfterQueryExecutionInfo()).isSameAs(queryExecutionInfo);
+        assertThat(queryExecutionInfo.getProxyEventType()).isEqualTo(ProxyEventType.AFTER_QUERY);
+        assertThat(queryExecutionInfo.getCurrentMappedResult()).isEqualTo(null);
+        assertThat(queryExecutionInfo.getCurrentMappedResult()).isNull();
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
-    void mapWithResultThatErrorsAtExecutionTime() throws Throwable {
+    void mapWithResultThatErrorsAtExecutionTimeWhenAllResultAreNotAlreadyGenerated() throws Throwable {
 
         // call to the "map()" method returns a publisher that fails(errors) at execution time
 
@@ -226,12 +405,15 @@ public class ResultCallbackHandlerTest {
             throw exception;
         };
 
+        QueriesExecutionCounter queriesExecutionCounter = new QueriesExecutionCounter(mock(StopWatch.class));
 
-        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig);
+        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig, queriesExecutionCounter);
 
         // since "mockResult.map()" is mocked, args can be anything as long as num of args matches to signature.
         Object[] args = new Object[]{mapBiFunction};
         Object result = callback.invoke(mockResult, MAP_METHOD, args);
+
+        queriesExecutionCounter.addGeneratedResult();
 
         assertThat(result)
             .isInstanceOf(Publisher.class);
@@ -251,6 +433,7 @@ public class ResultCallbackHandlerTest {
         // verify callback
         assertThat(listener.getEachQueryResultExecutionInfo()).isSameAs(queryExecutionInfo).as(
             "listener should be called even consuming throws exception");
+        assertThat(queriesExecutionCounter.areAllResultProcessed()).isTrue().as("there are only one result processing, so after .map all result are processed");
         assertThat(queryExecutionInfo.getProxyEventType()).isEqualTo(ProxyEventType.EACH_QUERY_RESULT);
         assertThat(queryExecutionInfo.getCurrentResultCount()).isEqualTo(1);
         assertThat(queryExecutionInfo.getCurrentMappedResult()).isNull();
@@ -265,8 +448,9 @@ public class ResultCallbackHandlerTest {
         Result mockResult = MockResult.empty();
         MutableQueryExecutionInfo queryExecutionInfo = new MutableQueryExecutionInfo();
         ProxyConfig proxyConfig = new ProxyConfig();
+        QueriesExecutionCounter queriesExecutionCounter = new QueriesExecutionCounter(mock(StopWatch.class));
 
-        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig);
+        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig, queriesExecutionCounter);
 
         Object result = callback.invoke(mockResult, UNWRAP_METHOD, null);
         assertThat(result).isSameAs(mockResult);
@@ -277,8 +461,9 @@ public class ResultCallbackHandlerTest {
         Result mockResult = MockResult.empty();
         MutableQueryExecutionInfo queryExecutionInfo = new MutableQueryExecutionInfo();
         ProxyConfig proxyConfig = new ProxyConfig();
+        QueriesExecutionCounter queriesExecutionCounter = new QueriesExecutionCounter(mock(StopWatch.class));
 
-        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig);
+        ResultCallbackHandler callback = new ResultCallbackHandler(mockResult, queryExecutionInfo, proxyConfig, queriesExecutionCounter);
 
         Object result = callback.invoke(mockResult, GET_PROXY_CONFIG_METHOD, null);
         assertThat(result).isSameAs(proxyConfig);


### PR DESCRIPTION
<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/main/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request. #94 
- [x] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/main/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

The afterQuery method is called even if the query is not executed. This can happen when binding is used.
 
#### New Public APIs

No new public API.

#### Additional context

This PR is a fix for issue #94.
With this PR the afterQuery function is called when all result are consumed, this mean that the query is fully executed. 

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
