### PR TITLE
127

### DIFF
--- a/src/main/java/io/r2dbc/proxy/callback/ConnectionCallbackHandler.java
+++ b/src/main/java/io/r2dbc/proxy/callback/ConnectionCallbackHandler.java
@@ -16,6 +16,7 @@
 
 package io.r2dbc.proxy.callback;
 
+import static io.r2dbc.proxy.callback.ContextViewPropagation.propagate;
 import io.r2dbc.proxy.core.ConnectionInfo;
 import io.r2dbc.proxy.core.MethodExecutionInfo;
 import io.r2dbc.proxy.util.Assert;
@@ -84,6 +85,7 @@ public final class ConnectionCallbackHandler extends CallbackHandlerSupport {
             MutableStatementInfo statementInfo = new MutableStatementInfo();
             statementInfo.setConnectionInfo(this.connectionInfo);
             statementInfo.setOriginalQuery(query);
+            propagate(connectionInfo, statementInfo);
 
             String updatedQuery = this.proxyConfig.getBindParameterConverter().onCreateStatement(query, statementInfo);
             statementInfo.setUpdatedQuery(updatedQuery);

--- a/src/main/java/io/r2dbc/proxy/callback/ConnectionFactoryCallbackHandler.java
+++ b/src/main/java/io/r2dbc/proxy/callback/ConnectionFactoryCallbackHandler.java
@@ -16,6 +16,7 @@
 
 package io.r2dbc.proxy.callback;
 
+import static io.r2dbc.proxy.callback.ContextViewPropagation.propagate;
 import io.r2dbc.proxy.core.ProxyEventType;
 import io.r2dbc.proxy.util.Assert;
 import io.r2dbc.spi.Connection;
@@ -92,6 +93,7 @@ public final class ConnectionFactoryCallbackHandler extends CallbackHandlerSuppo
                     connectionInfo.setOriginalConnection(connection);
                     executionInfo.setConnectionInfo(connectionInfo);
 
+                    propagate(executionInfo, connectionInfo);
                     Connection proxyConnection = this.proxyConfig.getProxyFactory().wrapConnection(connection, connectionInfo);
                     return proxyConnection;
                 })

--- a/src/main/java/io/r2dbc/proxy/callback/ContextViewPropagation.java
+++ b/src/main/java/io/r2dbc/proxy/callback/ContextViewPropagation.java
@@ -5,7 +5,7 @@ import io.r2dbc.proxy.core.MethodExecutionInfo;
 import io.r2dbc.proxy.core.StatementInfo;
 import reactor.util.context.ContextView;
 
-public class ContextViewPropagation {
+class ContextViewPropagation {
 
     private ContextViewPropagation() {
     }

--- a/src/main/java/io/r2dbc/proxy/callback/ContextViewPropagation.java
+++ b/src/main/java/io/r2dbc/proxy/callback/ContextViewPropagation.java
@@ -1,2 +1,28 @@
-package io.r2dbc.proxy.callback;public class ContextViewPropagation {
+package io.r2dbc.proxy.callback;
+
+import io.r2dbc.proxy.core.ConnectionInfo;
+import io.r2dbc.proxy.core.MethodExecutionInfo;
+import io.r2dbc.proxy.core.StatementInfo;
+import reactor.util.context.ContextView;
+
+public class ContextViewPropagation {
+
+    private ContextViewPropagation() {
+    }
+
+    static void propagate(MethodExecutionInfo executionInfo, ConnectionInfo connectionInfo) {
+        ContextView contextView = executionInfo.getValueStore().get(ContextView.class, ContextView.class);
+
+        if (contextView != null) {
+            connectionInfo.getValueStore().put(ContextView.class, contextView);
+        }
+    }
+
+    static void propagate(ConnectionInfo connectionInfo, StatementInfo statementInfo) {
+        ContextView contextView = connectionInfo.getValueStore().get(ContextView.class, ContextView.class);
+        if (contextView != null) {
+            statementInfo.getValueStore().put(ContextView.class, contextView);
+        }
+    }
+
 }

--- a/src/main/java/io/r2dbc/proxy/callback/ContextViewPropagation.java
+++ b/src/main/java/io/r2dbc/proxy/callback/ContextViewPropagation.java
@@ -1,0 +1,2 @@
+package io.r2dbc.proxy.callback;public class ContextViewPropagation {
+}

--- a/src/test/java/io/r2dbc/proxy/callback/ConnectionFactoryCallbackHandlerTest.java
+++ b/src/test/java/io/r2dbc/proxy/callback/ConnectionFactoryCallbackHandlerTest.java
@@ -44,6 +44,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import reactor.util.context.ContextView;
 
 /**
  * Test for {@link ConnectionFactoryCallbackHandler}.
@@ -109,6 +110,7 @@ public class ConnectionFactoryCallbackHandlerTest {
         assertThat(connectionInfo.getConnectionId()).isEqualTo(connectionId);
         assertThat(connectionInfo.isClosed()).isFalse();
         assertThat(connectionInfo.getOriginalConnection()).isSameAs(originalConnection);
+        assertThat(connectionInfo.getValueStore().get(ContextView.class)).isNotNull();
 
         assertThat(afterMethod.getTarget()).isSameAs(connectionFactory);
         assertThat(afterMethod.getResult()).isSameAs(originalConnection);

--- a/src/test/java/io/r2dbc/proxy/callback/ContextViewPropagationTest.java
+++ b/src/test/java/io/r2dbc/proxy/callback/ContextViewPropagationTest.java
@@ -1,0 +1,67 @@
+package io.r2dbc.proxy.callback;
+
+import org.junit.jupiter.api.Test;
+
+import static io.r2dbc.proxy.callback.ContextViewPropagation.propagate;
+import io.r2dbc.proxy.core.ConnectionInfo;
+import io.r2dbc.proxy.core.MethodExecutionInfo;
+import io.r2dbc.proxy.core.StatementInfo;
+import io.r2dbc.proxy.core.ValueStore;
+import io.r2dbc.proxy.test.MockConnectionInfo;
+import io.r2dbc.proxy.test.MockMethodExecutionInfo;
+import io.r2dbc.proxy.test.MockStatementInfo;
+import static org.assertj.core.api.Assertions.assertThat;
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+class ContextViewPropagationTest {
+
+    @Test
+    void propagateFromExecutionInfoToConnectionInfo() {
+        ContextView contextView = Context.of("key", "value");
+        MethodExecutionInfo executionInfo = MockMethodExecutionInfo.builder()
+                                                                   .customValue(ContextView.class, contextView)
+                                                                   .build();
+        ConnectionInfo connectionInfo = MockConnectionInfo.empty();
+        propagate(executionInfo, connectionInfo);
+
+        ContextView result = connectionInfo.getValueStore().get(ContextView.class, ContextView.class);
+        assertThat(result).isEqualTo(contextView);
+    }
+
+    @Test
+    void propagateFromExecutionInfoToConnectionInfoEmpty() {
+        MethodExecutionInfo executionInfo = MockMethodExecutionInfo.empty();
+        ConnectionInfo connectionInfo = MockConnectionInfo.empty();
+        propagate(executionInfo, connectionInfo);
+        ContextView result = connectionInfo.getValueStore().get(ContextView.class, ContextView.class);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void propagateFromConnectionInfoToStatementInfo() {
+        ContextView contextView = Context.of("key", "value");
+        ValueStore valueStore = ValueStore.create();
+        valueStore.put(ContextView.class, contextView);
+        ConnectionInfo connectionInfo = MockConnectionInfo.builder()
+                                                         .valueStore(valueStore)
+                                                         .build();
+
+        StatementInfo statementInfo = MockStatementInfo.empty();
+        propagate(connectionInfo, statementInfo);
+
+        ContextView result = statementInfo.getValueStore().get(ContextView.class, ContextView.class);
+        assertThat(result).isEqualTo(contextView);
+    }
+
+    @Test
+    void propagateFromConnectionInfoToStatementInfoEmpty() {
+        ConnectionInfo connectionInfo = MockConnectionInfo.empty();
+        StatementInfo statementInfo = MockStatementInfo.empty();
+
+        propagate(connectionInfo, statementInfo);
+        ContextView result = statementInfo.getValueStore().get(ContextView.class, ContextView.class);
+        assertThat(result).isNull();
+    }
+
+}


### PR DESCRIPTION
#### Issue description
This is an approach to issue #127. A package private class with static methods was created in order to propagate the `ContextView` from `MethodExecutionInfo` to `ConnectionInfo` as well ass from `ConnectionInfo` to `StatementInfo`.

If a different approach is more suitable, let me know and will change accordingly.