### PR TITLE
Change thread name from low to high cardinality

### DIFF
--- a/src/main/java/io/r2dbc/proxy/observation/QueryObservationConvention.java
+++ b/src/main/java/io/r2dbc/proxy/observation/QueryObservationConvention.java
@@ -51,7 +51,6 @@ public interface QueryObservationConvention extends ObservationConvention<QueryC
     default KeyValues getLowCardinalityKeyValues(QueryContext context) {
         Set<KeyValue> keyValues = new HashSet<>();
         keyValues.add(KeyValue.of(R2dbcObservationDocumentation.LowCardinalityKeys.CONNECTION, context.getConnectionName()));
-        keyValues.add(KeyValue.of(R2dbcObservationDocumentation.LowCardinalityKeys.THREAD, context.getThreadName()));
         return KeyValues.of(keyValues);
     }
 
@@ -69,6 +68,7 @@ public interface QueryObservationConvention extends ObservationConvention<QueryC
             String key = String.format(R2dbcObservationDocumentation.HighCardinalityKeys.QUERY_PARAMETERS.asString(), i);
             keyValues.add(KeyValue.of(key, params));
         }
+        keyValues.add(KeyValue.of(R2dbcObservationDocumentation.HighCardinalityKeys.THREAD, context.getThreadName()));
         return KeyValues.of(keyValues);
     }
 }

--- a/src/main/java/io/r2dbc/proxy/observation/R2dbcObservationDocumentation.java
+++ b/src/main/java/io/r2dbc/proxy/observation/R2dbcObservationDocumentation.java
@@ -89,16 +89,6 @@ public enum R2dbcObservationDocumentation implements ObservationDocumentation {
             public String asString() {
                 return "r2dbc.connection";
             }
-        },
-
-        /**
-         * Name of the R2DBC thread.
-         */
-        THREAD {
-            @Override
-            public String asString() {
-                return "r2dbc.thread";
-            }
         }
 
     }
@@ -122,6 +112,16 @@ public enum R2dbcObservationDocumentation implements ObservationDocumentation {
             @Override
             public String asString() {
                 return "r2dbc.params[%s]";
+            }
+        },
+
+        /**
+         * Name of the R2DBC thread.
+         */
+        THREAD {
+            @Override
+            public String asString() {
+                return "r2dbc.thread";
             }
         }
 


### PR DESCRIPTION
Thread name is a low cardinality key but with virtual threads there are millions of threads which leads to e.g. prometheus going 💥.

This change moves it to a high cardinality key instead.

Closes #149